### PR TITLE
Implementação de testes para a classe Date\Validation\BR

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
         "psr-4":{
             "DataTools\\":"src\\"
         }
+    },
+    "scripts": {
+      "test": "phpunit --colors test"
     }
 }

--- a/test/Date/Validation/BRTest.php
+++ b/test/Date/Validation/BRTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DataToolsTest\Date\Validation;
+namespace DateToolsTest\Date\Validation;
 
 use DataTools\Date\Validation\BR as Validator;
 

--- a/test/Date/Validation/BRTest.php
+++ b/test/Date/Validation/BRTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace DataToolsTest\Date\Validation;
+
+use DataTools\Date\Validation\BR as Validator;
+
+class BRTest extends \PHPUnit_Framework_TestCase
+{
+    public function testisEmptyWithNullDate()
+    {
+        $this->assertEquals(Validator::isEmpty(null), true);
+    }
+
+    public function testisEmptyWithStringDate()
+    {
+        $this->assertEquals(Validator::isEmpty('2016-12-25'), false);
+    }
+
+    public function testisEmptyWithZeroIntegerDate()
+    {
+        $this->assertEquals(Validator::isEmpty(0), false);
+    }
+
+    public function testIsValidWithValidDate()
+    {
+        $this->assertEquals(Validator::isValid('2016-12-25'), true);
+    }
+
+    public function testIsValidWithWrongSeparator()
+    {
+        $this->assertEquals(Validator::isValid('2016/12/25'), true);
+    }
+
+    public function testIsValidWithWrongNumberOfDigits()
+    {
+        $this->assertEquals(Validator::isValid('20165-12-25'), true);
+        $this->assertEquals(Validator::isValid('2016-121-25'), true);
+        $this->assertEquals(Validator::isValid('2016-12-252'), true);
+    }
+
+    public function testIsValidWithInvalidPartOfTheDate()
+    {
+        $this->assertEquals(Validator::isValid('2016-25-12'), false);
+        $this->assertEquals(Validator::isValid('2016-10-33'), false);
+    }
+
+    public function testIsValidWithNullDate()
+    {
+        $this->assertEquals(Validator::isValid(null), false);
+    }
+}


### PR DESCRIPTION
Neste branch foram realizadas as seguintes implementações:
- Inclusão de script 'test' para facilitar a execução dos testes através do comando 'composer run-script test', que aponta diretamente para a pasta test da aplicação.

- Criação de testes para os métodos 'isEmpty' e 'isValid' da classe Date\Validation\BR.

Este pull request fecha a issue #2 