### PR TITLE
Referente a issue #3 para testes da classe "DateTools\Date\Convertion\BR.php"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 index.php
 /vendor
+/test/_reports

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit 
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    syntaxCheck="false"
+    bootstrap="vendor/autoload.php"
+    addUncoveredFilesFromWhitelist="true"
+    processUncoveredFilesFromWhitelist="true"
+>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+    <testsuites>
+        <testsuite name="date">
+            <file>./test</file>
+        </testsuite>
+    </testsuites>
+    <!-- Code Coverage Configuration -->
+    <logging>
+        <log type="testdox-text" target="test/_reports/testdox/executed.txt"/>
+    </logging>
+</phpunit>

--- a/test/Date/Convertion/BRTest.php
+++ b/test/Date/Convertion/BRTest.php
@@ -16,7 +16,7 @@ class BRTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('09/01/2017', Convertion::convert('2017-01-09'));
     }
 
-    public function testIndalidDate()
+    public function testInvalidDate()
     {
         $this->assertEquals(false, Convertion::convert('09/01/2017'));
         $this->assertEquals(false, Convertion::convert('099/01/2017'));

--- a/test/Date/Convertion/BRTest.php
+++ b/test/Date/Convertion/BRTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace DateToolsTest\Date\Convertion;
+
+use DateTools\Date\Convertion\BR as Convertion;
+
+class BRTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEmptyDate()
+    {
+        $this->assertEquals(false, Convertion::convert(''));
+    }
+
+    public function testValidDate()
+    {
+        $this->assertEquals('09/01/2017', Convertion::convert('2017-01-09'));
+    }
+
+    public function testIndalidDate()
+    {
+        $this->assertEquals(false, Convertion::convert('09/01/2017'));
+        $this->assertEquals(false, Convertion::convert('099/01/2017'));
+        $this->assertEquals(false, Convertion::convert('099/001/2017'));
+        $this->assertEquals(false, Convertion::convert('099/001/02017'));
+        $this->assertEquals(false, Convertion::convert('2017-001-09'));
+        $this->assertEquals(false, Convertion::convert('2017-01-009'));
+        $this->assertEquals(false, Convertion::convert('2017-001-009'));
+        $this->assertEquals(false, Convertion::convert('9999-99-99'));
+        $this->assertEquals(false, Convertion::convert('2017-02-31'));
+    }
+
+    public function testIsValidWithNullDate()
+    {
+        $this->assertEquals(false, Convertion::convert(null));
+    }
+
+    public function testIsValidWithWrongSeparator()
+    {
+        $this->assertEquals(false, Convertion::convert('2017/02/31'));
+        $this->assertEquals(false, Convertion::convert('2017 02 31'));
+    }
+}

--- a/test/Date/Validation/BRTest.php
+++ b/test/Date/Validation/BRTest.php
@@ -2,7 +2,7 @@
 
 namespace DateToolsTest\Date\Validation;
 
-use DataTools\Date\Validation\BR as Validator;
+use DateTools\Date\Validation\BR as Validator;
 
 class BRTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
# Referente a issue #3 
- Implementação de testes para a classe DateTools\Date\Convertion\BR.php.
- Implementação do arquivo phpunit.xml, para coverage de testes.
- Correção de namespace.
- Inclusão do diretório test/_reports no ignore list.
